### PR TITLE
Recognize CC0-1.0 as a permissive license

### DIFF
--- a/README.md
+++ b/README.md
@@ -216,6 +216,7 @@ deps = Depscheck.dependencies()
 - BSD-2-Clause, BSD-3-Clause
 - ISC
 - Unlicense
+- CC0-1.0
 
 ### Weak Copyleft
 - LGPL-2.1, LGPL-3.0

--- a/lib/depscheck/license_aliases.ex
+++ b/lib/depscheck/license_aliases.ex
@@ -97,7 +97,13 @@ defmodule Depscheck.LicenseAliases do
     "mpl-v2.0" => "mpl-2-0",
     "mpl-v2-0" => "mpl-2-0",
     "mpl2" => "mpl-2-0",
-    "mpl2.0" => "mpl-2-0"
+    "mpl2.0" => "mpl-2-0",
+    # CC0-1.0 (public domain dedication) variations
+    "cc0" => "cc0-1-0",
+    "cc-0" => "cc0-1-0",
+    "cc0-1-0-universal" => "cc0-1-0",
+    "public-domain" => "cc0-1-0",
+    "publicdomain" => "cc0-1-0"
   }
 
   @doc """

--- a/lib/depscheck/license_knowledge.ex
+++ b/lib/depscheck/license_knowledge.ex
@@ -16,7 +16,8 @@ defmodule Depscheck.LicenseKnowledge do
     "BSD-0-Clause",
     "0BSD",
     "ISC",
-    "Unlicense"
+    "Unlicense",
+    "CC0-1.0"
   ]
 
   @weak_copyleft_licenses [
@@ -124,7 +125,7 @@ defmodule Depscheck.LicenseKnowledge do
   ## Examples
 
       iex> Depscheck.LicenseKnowledge.list_licenses_by_category(:permissive)
-      ["MIT", "Apache-2.0", "BSD-2-Clause", "BSD-3-Clause", "BSD-4-Clause", "BSD-0-Clause", "0BSD", "ISC", "Unlicense"]
+      ["MIT", "Apache-2.0", "BSD-2-Clause", "BSD-3-Clause", "BSD-4-Clause", "BSD-0-Clause", "0BSD", "ISC", "Unlicense", "CC0-1.0"]
   """
   @spec list_licenses_by_category(Types.license_category()) :: [String.t()]
   def list_licenses_by_category(:permissive), do: @permissive_licenses

--- a/test/depscheck/license_knowledge_test.exs
+++ b/test/depscheck/license_knowledge_test.exs
@@ -24,6 +24,10 @@ defmodule Depscheck.LicenseKnowledgeTest do
       assert LicenseKnowledge.get_category("ISC") == :permissive
     end
 
+    test "returns :permissive for CC0-1.0" do
+      assert LicenseKnowledge.get_category("CC0-1.0") == :permissive
+    end
+
     test "returns :weak_copyleft for LGPL" do
       assert LicenseKnowledge.get_category("LGPL-2.1") == :weak_copyleft
       assert LicenseKnowledge.get_category("LGPL-3.0") == :weak_copyleft
@@ -95,6 +99,14 @@ defmodule Depscheck.LicenseKnowledgeTest do
       assert LicenseKnowledge.get_category("bsd0") == :permissive
       assert LicenseKnowledge.get_category("zero-clause-bsd") == :permissive
       assert LicenseKnowledge.get_category("bsd-zero-clause") == :permissive
+    end
+
+    test "handles CC0-1.0 alias variations" do
+      assert LicenseKnowledge.get_category("CC0-1.0") == :permissive
+      assert LicenseKnowledge.get_category("CC0") == :permissive
+      assert LicenseKnowledge.get_category("CC-0") == :permissive
+      assert LicenseKnowledge.get_category("CC0 1.0 Universal") == :permissive
+      assert LicenseKnowledge.get_category("Public Domain") == :permissive
     end
 
     test "handles real-world license variations from dependency metadata" do
@@ -207,7 +219,8 @@ defmodule Depscheck.LicenseKnowledgeTest do
       assert "Apache-2.0" in licenses
       assert "BSD-0-Clause" in licenses
       assert "0BSD" in licenses
-      assert length(licenses) == 9
+      assert "CC0-1.0" in licenses
+      assert length(licenses) == 10
     end
 
     test "returns weak copyleft licenses" do


### PR DESCRIPTION
## Summary
- Add `CC0-1.0` to the permissive license category
- Add aliases for common CC0 spellings (`CC0`, `CC-0`, `CC0 1.0 Universal`, `Public Domain`)
- Add tests and update the supported-licenses docs

## Details

Closes #3. CC0-1.0 is a public domain dedication — it grants the broadest possible rights, so it belongs in the permissive bucket. Previously it fell through to `:unknown`/unlicensed handling, producing a misleading "you have no legal right to use it" warning for dependencies that are in fact freely usable.

Beyond the canonical `CC0-1.0`, dependency metadata in the wild spells this license several ways, so the alias map now resolves `CC0`, `CC-0`, `CC0 1.0 Universal`, and `Public Domain` to the same canonical form.