### PR TITLE
Expand supported license list and recognize SPDX -only/-or-later identifiers

### DIFF
--- a/README.md
+++ b/README.md
@@ -210,23 +210,50 @@ deps = Depscheck.dependencies()
 
 ## Supported Licenses
 
+License names are matched case-insensitively, and common spelling variations are
+normalized automatically (e.g. `Apache 2.0`, `apache-v2.0`, `GPLv3`). The SPDX
+`-only` / `-or-later` suffixes and the legacy `+` operator are recognized for the
+GNU family (e.g. `GPL-3.0-only`, `AGPL-3.0-or-later`, `LGPL-2.1+`).
+
 ### Permissive
-- MIT
-- Apache-2.0
-- BSD-2-Clause, BSD-3-Clause
+- MIT, MIT-0, X11
+- Apache-2.0, Apache-1.1
+- BSD-2-Clause, BSD-3-Clause, BSD-4-Clause, BSD-3-Clause-Clear
+- BSD-0-Clause / 0BSD
 - ISC
 - Unlicense
-- CC0-1.0
+- CC0-1.0, CC-BY-4.0
+- BSL-1.0 (Boost)
+- Zlib
+- NCSA
+- MS-PL
+- PostgreSQL
+- Python-2.0, PSF-2.0
+- Artistic-2.0
+- WTFPL
+- UPL-1.0
+- OFL-1.1
+- Vim
+- BlueOak-1.0.0
+- AFL-3.0
+- ECL-2.0
+- MulanPSL-2.0
 
 ### Weak Copyleft
-- LGPL-2.1, LGPL-3.0
-- MPL-2.0
-- EPL-2.0
-- CDDL-1.0
+- LGPL-2.0, LGPL-2.1, LGPL-3.0
+- MPL-1.1, MPL-2.0
+- EPL-1.0, EPL-2.0
+- CDDL-1.0, CDDL-1.1
+- MS-RL
+- LPPL-1.3c
 
 ### Strong Copyleft
-- GPL-2.0, GPL-3.0
+- GPL-1.0, GPL-2.0, GPL-3.0
 - AGPL-3.0
+- EUPL-1.1, EUPL-1.2
+- CECILL-2.1
+- OSL-3.0
+- SSPL-1.0
 
 ### Proprietary
 - All Rights Reserved

--- a/lib/depscheck/license_aliases.ex
+++ b/lib/depscheck/license_aliases.ex
@@ -11,71 +11,105 @@ defmodule Depscheck.LicenseAliases do
   The aliases are used during license normalization to ensure that different
   spellings of the same license are correctly identified.
 
+  `resolve/1` expects its argument to already be normalized (lowercase, dashes
+  for spaces, dash-separated version numbers), since it is the final step of the
+  normalization pipeline. The examples below use that normalized form.
+
   ## Examples
 
-      iex> Depscheck.LicenseAliases.resolve("apache-v2.0")
+      iex> Depscheck.LicenseAliases.resolve("apl-v2-0")
       "apache-2-0"
 
       iex> Depscheck.LicenseAliases.resolve("gplv2")
       "gpl-2-0"
 
-      iex> Depscheck.LicenseAliases.resolve("apl-2.0")
-      "apache-2-0"
+      iex> Depscheck.LicenseAliases.resolve("gpl-3-0-only")
+      "gpl-3-0"
   """
 
   # Mapping of license spelling variations/aliases to canonical names
   # Keys should be normalized (lowercase, trimmed) for matching
   # Values should use dash-separated version numbers (e.g., "2-0" not "2.0")
   # because normalize_common_variations converts "2.0" to "2-0"
+  #
+  # IMPORTANT: keys are matched *after* the rest of normalization has run, so
+  # they must be written in fully-normalized form: lowercase, dashes instead of
+  # spaces, and dash-separated version numbers ("2-0", never "2.0" — the dot is
+  # already gone by the time `resolve/1` is called). A key containing a dot can
+  # never match and is dead code.
   @aliases %{
-    # Apache 2.0 variations
-    "apache-v2.0" => "apache-2-0",
+    # Apache-2.0 variations
     "apache-v2-0" => "apache-2-0",
-    "apache-2.0" => "apache-2-0",
     "apache-v2" => "apache-2-0",
     "apache2" => "apache-2-0",
-    "apache2.0" => "apache-2-0",
+    "apache2-0" => "apache-2-0",
     # APL (typo/variation) -> Apache
-    "apl-2.0" => "apache-2-0",
     "apl-2-0" => "apache-2-0",
-    "apl-v2.0" => "apache-2-0",
     "apl-v2-0" => "apache-2-0",
     "apl-v2" => "apache-2-0",
     "apl2" => "apache-2-0",
-    "apl2.0" => "apache-2-0",
+    "apl2-0" => "apache-2-0",
+    # GPL-1.0 variations
+    "gplv1" => "gpl-1-0",
+    "gpl-v1" => "gpl-1-0",
+    "gpl1" => "gpl-1-0",
+    "gpl-1-0-only" => "gpl-1-0",
+    "gpl-1-0-or-later" => "gpl-1-0",
+    "gpl-1-0+" => "gpl-1-0",
     # GPL-2.0 variations
     "gplv2" => "gpl-2-0",
     "gpl-v2" => "gpl-2-0",
-    "gpl-v2.0" => "gpl-2-0",
     "gpl-v2-0" => "gpl-2-0",
     "gpl2" => "gpl-2-0",
-    "gpl2.0" => "gpl-2-0",
+    "gpl2-0" => "gpl-2-0",
+    # SPDX deprecated the bare "GPL-2.0" in favour of explicit "-only"/
+    # "-or-later" suffixes (and the legacy "+" operator). All map to the same
+    # compatibility category.
+    "gpl-2-0-only" => "gpl-2-0",
+    "gpl-2-0-or-later" => "gpl-2-0",
+    "gpl-2-0+" => "gpl-2-0",
     # GPL-3.0 variations
     "gplv3" => "gpl-3-0",
     "gpl-v3" => "gpl-3-0",
-    "gpl-v3.0" => "gpl-3-0",
     "gpl-v3-0" => "gpl-3-0",
     "gpl3" => "gpl-3-0",
-    "gpl3.0" => "gpl-3-0",
+    "gpl3-0" => "gpl-3-0",
+    "gpl-3-0-only" => "gpl-3-0",
+    "gpl-3-0-or-later" => "gpl-3-0",
+    "gpl-3-0+" => "gpl-3-0",
+    # LGPL-2.0 variations
+    "lgplv2" => "lgpl-2-0",
+    "lgpl-v2" => "lgpl-2-0",
+    "lgpl2" => "lgpl-2-0",
+    "lgpl2-0" => "lgpl-2-0",
+    "lgpl-2-0-only" => "lgpl-2-0",
+    "lgpl-2-0-or-later" => "lgpl-2-0",
+    "lgpl-2-0+" => "lgpl-2-0",
     # LGPL-2.1 variations
-    "lgplv2.1" => "lgpl-2-1",
-    "lgpl-v2.1" => "lgpl-2-1",
+    "lgplv2-1" => "lgpl-2-1",
     "lgpl-v2-1" => "lgpl-2-1",
-    "lgpl2.1" => "lgpl-2-1",
+    "lgpl2-1" => "lgpl-2-1",
+    "lgpl-2-1-only" => "lgpl-2-1",
+    "lgpl-2-1-or-later" => "lgpl-2-1",
+    "lgpl-2-1+" => "lgpl-2-1",
     # LGPL-3.0 variations
     "lgplv3" => "lgpl-3-0",
     "lgpl-v3" => "lgpl-3-0",
-    "lgpl-v3.0" => "lgpl-3-0",
     "lgpl-v3-0" => "lgpl-3-0",
     "lgpl3" => "lgpl-3-0",
-    "lgpl3.0" => "lgpl-3-0",
+    "lgpl3-0" => "lgpl-3-0",
+    "lgpl-3-0-only" => "lgpl-3-0",
+    "lgpl-3-0-or-later" => "lgpl-3-0",
+    "lgpl-3-0+" => "lgpl-3-0",
     # AGPL-3.0 variations
     "agplv3" => "agpl-3-0",
     "agpl-v3" => "agpl-3-0",
-    "agpl-v3.0" => "agpl-3-0",
     "agpl-v3-0" => "agpl-3-0",
     "agpl3" => "agpl-3-0",
-    "agpl3.0" => "agpl-3-0",
+    "agpl3-0" => "agpl-3-0",
+    "agpl-3-0-only" => "agpl-3-0",
+    "agpl-3-0-or-later" => "agpl-3-0",
+    "agpl-3-0+" => "agpl-3-0",
     # BSD variations
     "bsdv2" => "bsd-2-clause",
     "bsd-2" => "bsd-2-clause",
@@ -91,13 +125,59 @@ defmodule Depscheck.LicenseAliases do
     "0bsd" => "0bsd",
     "zero-clause-bsd" => "0bsd",
     "bsd-zero-clause" => "0bsd",
+    # MPL-1.1 variations
+    "mplv1-1" => "mpl-1-1",
+    "mpl-v1-1" => "mpl-1-1",
+    "mpl1-1" => "mpl-1-1",
     # MPL-2.0 variations
     "mplv2" => "mpl-2-0",
     "mpl-v2" => "mpl-2-0",
-    "mpl-v2.0" => "mpl-2-0",
     "mpl-v2-0" => "mpl-2-0",
     "mpl2" => "mpl-2-0",
-    "mpl2.0" => "mpl-2-0",
+    "mpl2-0" => "mpl-2-0",
+    # EPL (Eclipse Public License) variations
+    "eplv1" => "epl-1-0",
+    "epl1" => "epl-1-0",
+    "eplv2" => "epl-2-0",
+    "epl2" => "epl-2-0",
+    # Boost Software License -> BSL-1.0
+    "boost" => "bsl-1-0",
+    "boost-1-0" => "bsl-1-0",
+    "boost-software-license" => "bsl-1-0",
+    "bsl" => "bsl-1-0",
+    # Python Software Foundation / Python-2.0
+    "python" => "python-2-0",
+    "psf" => "psf-2-0",
+    "psfl" => "psf-2-0",
+    # SIL Open Font License -> OFL-1.1
+    "ofl" => "ofl-1-1",
+    "sil-ofl-1-1" => "ofl-1-1",
+    "openfont" => "ofl-1-1",
+    # Artistic License -> Artistic-2.0
+    "artistic" => "artistic-2-0",
+    "artistic-2" => "artistic-2-0",
+    # Microsoft Public / Reciprocal License
+    "mspl" => "ms-pl",
+    "ms-public-license" => "ms-pl",
+    "msrl" => "ms-rl",
+    # Open Software License -> OSL-3.0
+    "osl" => "osl-3-0",
+    "osl3" => "osl-3-0",
+    # EUPL (European Union Public License) variations
+    "eupl" => "eupl-1-2",
+    "eupl1-2" => "eupl-1-2",
+    "eupl-v1-2" => "eupl-1-2",
+    "eupl1-1" => "eupl-1-1",
+    # Server Side Public License -> SSPL-1.0
+    "sspl" => "sspl-1-0",
+    "sspl-v1" => "sspl-1-0",
+    # X11 -> distinct SPDX id but commonly conflated with MIT
+    "mit-x11" => "x11",
+    # WTFPL variations
+    "wtfplv2" => "wtfpl",
+    "wtfpl-2" => "wtfpl",
+    # Zlib variations
+    "zlib-libpng" => "zlib",
     # CC0-1.0 (public domain dedication) variations
     "cc0" => "cc0-1-0",
     "cc-0" => "cc0-1-0",
@@ -114,11 +194,11 @@ defmodule Depscheck.LicenseAliases do
 
   ## Examples
 
-      iex> Depscheck.LicenseAliases.resolve("apache-v2.0")
-      "apache-2.0"
+      iex> Depscheck.LicenseAliases.resolve("apl-v2-0")
+      "apache-2-0"
 
       iex> Depscheck.LicenseAliases.resolve("gplv2")
-      "gpl-2.0"
+      "gpl-2-0"
 
       iex> Depscheck.LicenseAliases.resolve("unknown-license")
       "unknown-license"

--- a/lib/depscheck/license_knowledge.ex
+++ b/lib/depscheck/license_knowledge.ex
@@ -9,29 +9,62 @@ defmodule Depscheck.LicenseKnowledge do
 
   @permissive_licenses [
     "MIT",
+    "MIT-0",
+    "X11",
     "Apache-2.0",
+    "Apache-1.1",
     "BSD-2-Clause",
     "BSD-3-Clause",
     "BSD-4-Clause",
     "BSD-0-Clause",
     "0BSD",
+    "BSD-3-Clause-Clear",
     "ISC",
     "Unlicense",
-    "CC0-1.0"
+    "CC0-1.0",
+    "BSL-1.0",
+    "Zlib",
+    "NCSA",
+    "MS-PL",
+    "PostgreSQL",
+    "Python-2.0",
+    "PSF-2.0",
+    "Artistic-2.0",
+    "WTFPL",
+    "UPL-1.0",
+    "OFL-1.1",
+    "Vim",
+    "BlueOak-1.0.0",
+    "AFL-3.0",
+    "ECL-2.0",
+    "MulanPSL-2.0",
+    "CC-BY-4.0"
   ]
 
   @weak_copyleft_licenses [
+    "LGPL-2.0",
     "LGPL-2.1",
     "LGPL-3.0",
+    "MPL-1.1",
     "MPL-2.0",
+    "EPL-1.0",
     "EPL-2.0",
-    "CDDL-1.0"
+    "CDDL-1.0",
+    "CDDL-1.1",
+    "MS-RL",
+    "LPPL-1.3c"
   ]
 
   @strong_copyleft_licenses [
+    "GPL-1.0",
     "GPL-2.0",
     "GPL-3.0",
-    "AGPL-3.0"
+    "AGPL-3.0",
+    "EUPL-1.1",
+    "EUPL-1.2",
+    "CECILL-2.1",
+    "OSL-3.0",
+    "SSPL-1.0"
   ]
 
   @proprietary_licenses [
@@ -124,8 +157,8 @@ defmodule Depscheck.LicenseKnowledge do
 
   ## Examples
 
-      iex> Depscheck.LicenseKnowledge.list_licenses_by_category(:permissive)
-      ["MIT", "Apache-2.0", "BSD-2-Clause", "BSD-3-Clause", "BSD-4-Clause", "BSD-0-Clause", "0BSD", "ISC", "Unlicense", "CC0-1.0"]
+      iex> :permissive |> Depscheck.LicenseKnowledge.list_licenses_by_category() |> Enum.take(3)
+      ["MIT", "MIT-0", "X11"]
   """
   @spec list_licenses_by_category(Types.license_category()) :: [String.t()]
   def list_licenses_by_category(:permissive), do: @permissive_licenses

--- a/test/depscheck/license_knowledge_test.exs
+++ b/test/depscheck/license_knowledge_test.exs
@@ -131,6 +131,45 @@ defmodule Depscheck.LicenseKnowledgeTest do
       assert LicenseKnowledge.get_category("APL 2.0") == :permissive
     end
 
+    test "handles SPDX -only / -or-later / + GPL-family variants" do
+      # SPDX deprecated the bare "GPL-3.0" in favour of these forms; all must
+      # still resolve to the correct copyleft category.
+      assert LicenseKnowledge.get_category("GPL-2.0-only") == :strong_copyleft
+      assert LicenseKnowledge.get_category("GPL-2.0-or-later") == :strong_copyleft
+      assert LicenseKnowledge.get_category("GPL-3.0-only") == :strong_copyleft
+      assert LicenseKnowledge.get_category("GPL-3.0-or-later") == :strong_copyleft
+      assert LicenseKnowledge.get_category("GPL-3.0+") == :strong_copyleft
+      assert LicenseKnowledge.get_category("AGPL-3.0-only") == :strong_copyleft
+      assert LicenseKnowledge.get_category("AGPL-3.0-or-later") == :strong_copyleft
+      assert LicenseKnowledge.get_category("LGPL-2.1-only") == :weak_copyleft
+      assert LicenseKnowledge.get_category("LGPL-3.0-or-later") == :weak_copyleft
+      assert LicenseKnowledge.get_category("LGPL-3.0+") == :weak_copyleft
+    end
+
+    test "recognizes additional common permissive licenses" do
+      assert LicenseKnowledge.get_category("BSL-1.0") == :permissive
+      assert LicenseKnowledge.get_category("Boost") == :permissive
+      assert LicenseKnowledge.get_category("Zlib") == :permissive
+      assert LicenseKnowledge.get_category("Artistic-2.0") == :permissive
+      assert LicenseKnowledge.get_category("WTFPL") == :permissive
+      assert LicenseKnowledge.get_category("MIT-0") == :permissive
+      assert LicenseKnowledge.get_category("NCSA") == :permissive
+      assert LicenseKnowledge.get_category("MS-PL") == :permissive
+      assert LicenseKnowledge.get_category("PostgreSQL") == :permissive
+      assert LicenseKnowledge.get_category("Python-2.0") == :permissive
+      assert LicenseKnowledge.get_category("OFL-1.1") == :permissive
+    end
+
+    test "recognizes additional copyleft licenses" do
+      assert LicenseKnowledge.get_category("LGPL-2.0") == :weak_copyleft
+      assert LicenseKnowledge.get_category("EPL-1.0") == :weak_copyleft
+      assert LicenseKnowledge.get_category("MPL-1.1") == :weak_copyleft
+      assert LicenseKnowledge.get_category("MS-RL") == :weak_copyleft
+      assert LicenseKnowledge.get_category("EUPL-1.2") == :strong_copyleft
+      assert LicenseKnowledge.get_category("OSL-3.0") == :strong_copyleft
+      assert LicenseKnowledge.get_category("SSPL-1.0") == :strong_copyleft
+    end
+
     test "handles complex spacing and punctuation variations" do
       # Multiple spaces
       assert LicenseKnowledge.get_category("Apache  2.0") == :permissive
@@ -220,21 +259,25 @@ defmodule Depscheck.LicenseKnowledgeTest do
       assert "BSD-0-Clause" in licenses
       assert "0BSD" in licenses
       assert "CC0-1.0" in licenses
-      assert length(licenses) == 10
+      assert "BSL-1.0" in licenses
+      assert "Zlib" in licenses
+      assert length(licenses) == 31
     end
 
     test "returns weak copyleft licenses" do
       licenses = LicenseKnowledge.list_licenses_by_category(:weak_copyleft)
       assert "LGPL-3.0" in licenses
       assert "MPL-2.0" in licenses
-      assert length(licenses) == 5
+      assert "EPL-1.0" in licenses
+      assert length(licenses) == 11
     end
 
     test "returns strong copyleft licenses" do
       licenses = LicenseKnowledge.list_licenses_by_category(:strong_copyleft)
       assert "GPL-3.0" in licenses
       assert "AGPL-3.0" in licenses
-      assert length(licenses) == 3
+      assert "EUPL-1.2" in licenses
+      assert length(licenses) == 9
     end
 
     test "returns proprietary licenses" do


### PR DESCRIPTION
## Summary

- Recognize SPDX `-only` / `-or-later` suffixes and the legacy `+` operator for the GNU family (GPL/LGPL/AGPL)
- Expand the categorized license lists from 10/5/3 to 31/11/9, adding commonly-encountered permissive and copyleft licenses
- Fix dead dotted alias keys that could never match after normalization, and correct stale doctests

## Details

The supported-license knowledge base was checked against the current SPDX License List (v3.28.0) and choosealicense.com's curated common-license set, surfacing two real gaps.

First, SPDX deprecated the bare `GPL-2.0`/`GPL-3.0`/`LGPL-*`/`AGPL-3.0` identifiers in favour of explicit `-only`/`-or-later` suffixes (and the older `+` operator). Hex packages declare these forms, but none of them were matched — a `GPL-3.0-only` dependency was silently treated as unknown (compatible-with-a-warning) rather than strong copyleft. These now resolve to the correct copyleft category.

Second, a latent normalization bug: alias keys are matched after version dots are converted to dashes (`2.0` → `2-0`), so every dotted alias key (`gpl2.0`, `apache2.0`, etc.) was dead code that could never fire. The alias map was rewritten with keys in fully-normalized dash form, closing those coverage gaps, with a comment documenting the invariant.

Alongside the fixes, the three category lists gained the licenses most likely to appear in dependency metadata — Zlib, BSL-1.0 (Boost), Artistic-2.0, WTFPL, MIT-0, NCSA, MS-PL, PostgreSQL, EPL-1.0, MPL-1.1, EUPL, OSL-3.0, SSPL-1.0 and others. Internal canonical names stay as the bare forms with SPDX variants aliased onto them, which collapses the `-only`/`-or-later` distinction into one category — correct for compatibility checking since all three carry the same obligations.

The README's "Supported Licenses" section and the module doctests were updated to match, and new tests lock in the SPDX variants and added licenses.